### PR TITLE
Add icecast2.sh script for installing and configuring Icecast2 server

### DIFF
--- a/icecast2.sh
+++ b/icecast2.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# Clear terminal
+clear
+
+if ! curl -s -o /tmp/functions.sh https://raw.githubusercontent.com/RFM-Hits/bash-functions/main/common-functions.sh; then
+    echo "*** Error: Failed to download common functions library. Check your internet connection."
+    exit 1
+fi
+
+# Source the functions
+source /tmp/functions.sh
+
+# Start Banner
+cat << "EOF"
+_______________  ___  _   _ _____ _____ _____                  
+| ___ \  ___|  \/  | | | | |_   _|_   _/  ___|                 
+| |_/ / |_  | .  . | | |_| | | |   | | \ `--.                  
+|    /|  _| | |\/| | |  _  | | |   | |  `--. \                 
+| |\ \| |   | |  | | | | | |_| |_  | | /\__/ /                 
+\_| \_\_|   \_|  |_/ \_| |_/\___/  \_/ \____/                  
+  ___  _   _______ _____ _____   _____ _____ ___  _____  _   __
+ / _ \| | | |  _  \_   _|  _  | /  ___|_   _/ _ \/  __ \| | / /
+/ /_\ \ | | | | | | | | | | | | \ `--.  | |/ /_\ \ /  \/| |/ / 
+|  _  | | | | | | | | | | | | |  `--. \ | ||  _  | |    |    \ 
+| | | | |_| | |/ / _| |_\ \_/ / /\__/ / | || | | | \__/\| |\  \
+\_| |_/\___/|___/  \___/ \___/  \____/  \_/\_| |_/\____/\_| \_/
+                                                               
+              
+******************************************************************
+ICECAST 2 INSTALLER - RFM HITS - Version 1.0
+******************************************************************                                                 
+EOF
+
+# Configure environment
+set_colors
+check_privileges privileged
+is_linux
+is_64bit
+set_timezone Europe/Amsterdam
+
+# Collect input from user
+ask_user "HOSTNAME" "localhost" "Enter the hostname or IP address of the server" "str"
+ask_user "SOURCEPASS" "hackme" "Specify the source and relay password" "str"
+ask_user "ADMINPASS" "hackme" "Specify the admin password" "str"
+ask_user "LOCATED" "Earth" "Where is this server located (visible on admin pages)?" "str"
+ask_user "ADMINMAIL" "root@localhost.local" "What's the admins e-mail (visible on admin pages and for let's encrypt)?" "email"
+ask_user "PORT" "80" "Specify the port" "num"
+ask_user "SSL" "n" "Do you want Let's Encrypt to get a certificate for this server? (y/n)" "y/n"
+
+# Set environment variables
+export DEBIAN_FRONTEND=noninteractive
+
+# Update and install packages
+update_os silent
+install_packages icecast2 certbot
+
+# Generate Icecast2 configuration
+ICECAST_XML="/etc/icecast2/icecast.xml"
+CAT <<EOF > "$ICECAST_XML"
+<icecast>
+    <location>$LOCATED</location>
+    <admin>$ADMINMAIL</admin>
+    <hostname>$HOSTNAME</hostname>
+
+    <limits>
+        <clients>10000</clients>
+        <sources>30</sources>
+        <burst-size>65535</burst-size>
+    </limits>
+
+    <authentication>
+        <source-password>$SOURCEPASS</source-password>
+        <relay-password>$SOURCEPASS</relay-password>
+        <admin-user>admin</admin-user>
+        <admin-password>$ADMINPASS</admin-password>
+    </authentication>
+
+    <listen-socket>
+        <port>$PORT</port>
+    </listen-socket>
+
+    <http-headers>
+        <header name="Access-Control-Allow-Origin" value="*" />
+        <header name="X-Robots-Tag" value="noindex" />
+    </http-headers>
+
+    <paths>
+        <basedir>/usr/share/icecast2</basedir>
+        <logdir>/var/log/icecast2</logdir>
+        <webroot>/usr/share/icecast2/web</webroot>
+        <adminroot>/usr/share/icecast2/admin</adminroot>
+        <alias source="/" dest="/status.xsl"/>
+    </paths>
+
+    <logging>
+        <accesslog>access.log</accesslog>
+        <errorlog>error.log</errorlog>
+        <loglevel>3</loglevel>
+        <logsize>10000</logsize>
+    </logging>
+</icecast>
+EOF


### PR DESCRIPTION
This pull request adds a new script, `icecast2.sh`, which installs and configures an Icecast2 server. The script includes options for setting the hostname, source and relay password, admin password, server location, admin email, and port. It also supports SSL configuration using Let's Encrypt. The script generates an Icecast2 configuration file and restarts the Icecast2 service.